### PR TITLE
Fix to allow Torch to run as a service.

### DIFF
--- a/Torch.Server/TorchService.cs
+++ b/Torch.Server/TorchService.cs
@@ -31,7 +31,7 @@ namespace Torch.Server
         {
             base.OnStart(args);
 
-            string configName = args.Length > 0 ? args[0] : "TorchConfig.xml";
+            string configName = args.Length > 0 ? args[0] : "Torch.cfg";
             var options = new TorchConfig("Torch");
             if (File.Exists(configName))
                 options = TorchConfig.LoadFrom(configName);

--- a/Torch/TorchBase.cs
+++ b/Torch/TorchBase.cs
@@ -229,7 +229,11 @@ namespace Torch
             TorchVersion = Assembly.GetEntryAssembly().GetName().Version;
             GameVersion = new Version(new MyVersion(MyPerGameSettings.BasicGameInfo.GameVersion.Value).FormattedText.ToString().Replace("_", "."));
             var verInfo = $"{Config.InstanceName} - Torch {TorchVersion}, SE {GameVersion}";
-            Console.Title = verInfo;
+            try { Console.Title = verInfo; }
+            catch { 
+                ///Running as service 
+            }
+
 #if DEBUG
             Log.Info("DEBUG");
 #else


### PR DESCRIPTION
This fixes the "Service cannot be started. System.IO.IOException: The handle is invalid." error when running as a service & it sets the default config file to Torch.cfg.

Changes:
- Catch an error caused by setting the Console Title when running as a service.
- Change the default config file for service mode to use Torch.cfg instead of TochConfig.xml.