### PR TITLE
Multiplayer Authentication Hook Removal

### DIFF
--- a/Torch/Managers/MultiplayerManager.cs
+++ b/Torch/Managers/MultiplayerManager.cs
@@ -203,7 +203,7 @@ namespace Torch.Managers
         /// </summary>
         private static void RemoveHandlers()
         {
-            var eventField = typeof(GameServer).GetField("<backing_store>ValidateAuthTicketResponse", BindingFlags.NonPublic | BindingFlags.Instance);
+            var eventField = typeof(GameServer).GetField("<backing_store>" + nameof(SteamServerAPI.Instance.GameServer.ValidateAuthTicketResponse), BindingFlags.NonPublic | BindingFlags.Instance);
             if (eventField?.GetValue(SteamServerAPI.Instance.GameServer) is MulticastDelegate eventDel)
             {
                 foreach (var handle in eventDel.GetInvocationList())
@@ -217,9 +217,9 @@ namespace Torch.Managers
                 }
             }
             else
-                Log.Warn("Unable to unhook the ValidateAuthTicketResponse event");
+                Log.Warn("Unable to unhook GameServer_ValidateAuthTicketResponse from the ValidateAuthTicketResponse event");
 
-            eventField = typeof(GameServer).GetField("<backing_store>UserGroupStatusResponse", BindingFlags.NonPublic | BindingFlags.Instance);
+            eventField = typeof(GameServer).GetField("<backing_store>" + nameof(SteamServerAPI.Instance.GameServer.UserGroupStatus), BindingFlags.NonPublic | BindingFlags.Instance);
             eventDel = eventField?.GetValue(SteamServerAPI.Instance.GameServer) as MulticastDelegate;
             if (eventDel != null)
             {
@@ -232,7 +232,7 @@ namespace Torch.Managers
                     }
                 }
             } else
-                Log.Warn("Unable to unhook the UserGroupStatusResponse event");
+                Log.Warn("Unable to unhook GameServer_UserGroupStatus from the UserGroupStatusResponse event");
         }
 
         //Largely copied from SE

--- a/Torch/Managers/MultiplayerManager.cs
+++ b/Torch/Managers/MultiplayerManager.cs
@@ -210,12 +210,16 @@ namespace Torch.Managers
                 {
                     if (handle.Method.Name == "GameServer_ValidateAuthTicketResponse")
                     {
-                        SteamServerAPI.Instance.GameServer.ValidateAuthTicketResponse -= handle as ValidateAuthTicketResponse;
+                        SteamServerAPI.Instance.GameServer.ValidateAuthTicketResponse -=
+                            handle as ValidateAuthTicketResponse;
                         Log.Debug("Removed GameServer_ValidateAuthTicketResponse");
                     }
                 }
             }
-            eventField = typeof(GameServer).GetField("<backing_store>UserGroupStatus", BindingFlags.NonPublic | BindingFlags.Instance);
+            else
+                Log.Warn("Unable to unhook the ValidateAuthTicketResponse event");
+
+            eventField = typeof(GameServer).GetField("<backing_store>UserGroupStatusResponse", BindingFlags.NonPublic | BindingFlags.Instance);
             eventDel = eventField?.GetValue(SteamServerAPI.Instance.GameServer) as MulticastDelegate;
             if (eventDel != null)
             {
@@ -227,7 +231,8 @@ namespace Torch.Managers
                         Log.Debug("Removed GameServer_UserGroupStatus");
                     }
                 }
-            }
+            } else
+                Log.Warn("Unable to unhook the UserGroupStatusResponse event");
         }
 
         //Largely copied from SE
@@ -337,7 +342,6 @@ namespace Torch.Managers
 
         private void UserAccepted(ulong steamId)
         {
-            _members.Remove(steamId);
             typeof(MyDedicatedServerBase).GetMethod("UserAccepted", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(MyMultiplayer.Static, new object[] {steamId});
             var vm = new PlayerViewModel(steamId) {State = ConnectionState.Connected};
             Log.Info($"Player {vm.Name} joined ({vm.SteamId})");


### PR DESCRIPTION
Fixed the underlying issue with #69, and removed the workaround.
Additionally added some compile time checking using `nameof` instead of hard coded names.