### PR TITLE
Check if thread is running before suspending

### DIFF
--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -30,6 +30,8 @@ using VRage.Library;
 using VRage.ObjectBuilders;
 using VRage.Plugins;
 using VRage.Utils;
+using ThreadState = System.Threading.ThreadState;
+
 #pragma warning disable 618
 
 namespace Torch.Server
@@ -182,7 +184,8 @@ namespace Torch.Server
             if (!mre.WaitOne(TimeSpan.FromSeconds(Instance.Config.TickTimeout)))
             {
                 var mainThread = MySandboxGame.Static.UpdateThread;
-                mainThread.Suspend();
+                if (mainThread.ThreadState == ThreadState.Running)
+                    mainThread.Suspend();
                 var stackTrace = new StackTrace(mainThread, true);
                 throw new TimeoutException($"Server watchdog detected that the server was frozen for at least {((TorchServer)state).Config.TickTimeout} seconds.\n{stackTrace}");
             }

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -30,7 +30,6 @@ using VRage.Library;
 using VRage.ObjectBuilders;
 using VRage.Plugins;
 using VRage.Utils;
-using ThreadState = System.Threading.ThreadState;
 
 #pragma warning disable 618
 
@@ -184,7 +183,7 @@ namespace Torch.Server
             if (!mre.WaitOne(TimeSpan.FromSeconds(Instance.Config.TickTimeout)))
             {
                 var mainThread = MySandboxGame.Static.UpdateThread;
-                if (mainThread.ThreadState == ThreadState.Running)
+                if (mainThread.ThreadState == System.Threading.ThreadState.Running)
                     mainThread.Suspend();
                 var stackTrace = new StackTrace(mainThread, true);
                 throw new TimeoutException($"Server watchdog detected that the server was frozen for at least {((TorchServer)state).Config.TickTimeout} seconds.\n{stackTrace}");

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -183,7 +183,7 @@ namespace Torch.Server
             if (!mre.WaitOne(TimeSpan.FromSeconds(Instance.Config.TickTimeout)))
             {
                 var mainThread = MySandboxGame.Static.UpdateThread;
-                if (mainThread.ThreadState == System.Threading.ThreadState.Running)
+                if (mainThread.IsAlive)
                     mainThread.Suspend();
                 var stackTrace = new StackTrace(mainThread, true);
                 throw new TimeoutException($"Server watchdog detected that the server was frozen for at least {((TorchServer)state).Config.TickTimeout} seconds.\n{stackTrace}");


### PR DESCRIPTION
Fixes a bug noticed in Essentials issue 8 https://github.com/TorchAPI/Essentials/issues/8