### PR TITLE
Fix dependent DLL loading

### DIFF
--- a/Torch/Plugins/PluginManager.cs
+++ b/Torch/Plugins/PluginManager.cs
@@ -272,6 +272,7 @@ namespace Torch.Managers
                         stream.Read(data, 0, data.Length);
                         Assembly asm = Assembly.Load(data);
                         TorchBase.RegisterAuxAssembly(asm);
+                        assemblies.Add(asm);
                     }
                 }
             }

--- a/Torch/Plugins/PluginManager.cs
+++ b/Torch/Plugins/PluginManager.cs
@@ -232,7 +232,7 @@ namespace Torch.Managers
 
             foreach (var file in files)
             {
-                if (!file.Contains(".dll", StringComparison.CurrentCultureIgnoreCase))
+                if (!file.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
                     continue;
 
                 using (var stream = File.OpenRead(file))
@@ -263,7 +263,7 @@ namespace Torch.Managers
 
                 foreach (var entry in zipFile.Entries)
                 {
-                    if (!entry.Name.Contains(".dll", StringComparison.CurrentCultureIgnoreCase))
+                    if (!entry.Name.EndsWith(".dll", StringComparison.CurrentCultureIgnoreCase))
                         continue;
 
                     using (var stream = entry.Open())


### PR DESCRIPTION
It is a bunch of fixes, the main issue was that I'm using a package from NuGet in my plugin. But that package has other NuGet package dependencies, and those packages have more dependencies, ... etc.

Those DLLs need to be loaded in a proper order, I implemented it with the AssemblyResolve event.

Other fixes:
- load only *.dll files, but not files like *.dll.xml
- actually instantiate the plugin from zip