### PR TITLE
Load order

### DIFF
--- a/NLog.config
+++ b/NLog.config
@@ -14,6 +14,7 @@
   </targets>
 
   <rules>
+    <logger name="Keen" minlevel="Warn" writeTo="main"/>
     <logger name="Keen" minlevel="Info" writeTo="console"/>
     <logger name="Keen" minlevel="Debug" writeTo="keen" final="true" />
     <logger name="Keen" writeTo="null" final="true" />

--- a/Torch/Event/EventList.cs
+++ b/Torch/Event/EventList.cs
@@ -75,11 +75,6 @@ namespace Torch.Event
                         removeCount++;
                         i--;
                     }
-                if (removeCount > 0)
-                {
-                    _dispatchersDirty = true;
-                    _dispatchers.RemoveRange(_dispatchers.Count - removeCount, removeCount);
-                }
                 return removeCount;
             }
             finally

--- a/Torch/Managers/PatchManager/DecoratedMethod.cs
+++ b/Torch/Managers/PatchManager/DecoratedMethod.cs
@@ -99,14 +99,6 @@ namespace Torch.Managers.PatchManager
         public const string RESULT_PARAMETER = "__result";
         public const string PREFIX_SKIPPED_PARAMETER = "__prefixSkipped";
 
-#pragma warning disable 649
-        [ReflectedStaticMethod(Type = typeof(RuntimeHelpers), Name = "_CompileMethod", OverrideTypeNames = new[] { "System.IRuntimeMethodInfo" })]
-        private static Action<object> _compileDynamicMethod;
-        [ReflectedMethod(Name = "GetMethodInfo")]
-        private static Func<RuntimeMethodHandle, object> _getMethodInfo;
-        [ReflectedMethod(Name = "GetMethodDescriptor")]
-        private static Func<DynamicMethod, RuntimeMethodHandle> _getMethodHandle;
-#pragma warning restore 649
 
         public DynamicMethod ComposePatchedMethod()
         {
@@ -124,10 +116,7 @@ namespace Torch.Managers.PatchManager
 
             try
             {
-                // Force it to compile
-                RuntimeMethodHandle handle = _getMethodHandle.Invoke(method);
-                object runtimeMethodInfo = _getMethodInfo.Invoke(handle);
-                _compileDynamicMethod.Invoke(runtimeMethodInfo);
+                PatchUtilities.Compile(method);
             }
             catch
             {

--- a/Torch/Managers/PatchManager/MSIL/MsilOperandInline.cs
+++ b/Torch/Managers/PatchManager/MSIL/MsilOperandInline.cs
@@ -426,16 +426,16 @@ namespace Torch.Managers.PatchManager.MSIL
                 {
                     case OperandType.InlineTok:
                         Debug.Assert(Value is MethodBase || Value is Type || Value is FieldInfo,
-                            $"Value {Value?.GetType()} doesn't match operand type");
+                            $"Value {Value?.GetType()} doesn't match operand type for {Instruction.OpCode}");
                         break;
                     case OperandType.InlineType:
-                        Debug.Assert(Value is Type, $"Value {Value?.GetType()} doesn't match operand type");
+                        Debug.Assert(Value is Type, $"Value {Value?.GetType()} doesn't match operand type for {Instruction.OpCode}");
                         break;
                     case OperandType.InlineMethod:
-                        Debug.Assert(Value is MethodBase, $"Value {Value?.GetType()} doesn't match operand type");
+                        Debug.Assert(Value is MethodBase, $"Value {Value?.GetType()} doesn't match operand type for {Instruction.OpCode}");
                         break;
                     case OperandType.InlineField:
-                        Debug.Assert(Value is FieldInfo, $"Value {Value?.GetType()} doesn't match operand type");
+                        Debug.Assert(Value is FieldInfo, $"Value {Value?.GetType()} doesn't match operand type for {Instruction.OpCode}");
                         break;
                     default:
                         throw new InvalidBranchException(

--- a/Torch/TorchBase.cs
+++ b/Torch/TorchBase.cs
@@ -231,6 +231,14 @@ namespace Torch
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void InvokeBlocking(Action action, int timeoutMs = -1, [CallerMemberName] string caller = "")
         {
+            if (Thread.CurrentThread == MySandboxGame.Static.UpdateThread)
+            {
+                Debug.Assert(false, $"{nameof(InvokeBlocking)} should not be called on the game thread.");
+                // ReSharper disable once HeuristicUnreachableCode
+                action.Invoke();
+                return;
+            }
+
             // ReSharper disable once ExplicitCallerInfoArgument
             Task task = InvokeAsync(action, caller);
             if (!task.Wait(timeoutMs))
@@ -243,19 +251,6 @@ namespace Torch
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Task<T> InvokeAsync<T>(Func<T> action, [CallerMemberName] string caller = "")
         {
-            if (Thread.CurrentThread == MySandboxGame.Static.UpdateThread)
-            {
-                Debug.Assert(false, $"{nameof(InvokeAsync)} should not be called on the game thread.");
-                // ReSharper disable once HeuristicUnreachableCode
-                try
-                {
-                    return Task.FromResult(action.Invoke());
-                }
-                catch (Exception e)
-                {
-                    return Task.FromException<T>(e);
-                }
-            }
             var ctx = new TaskCompletionSource<T>();
             MySandboxGame.Static.Invoke(() =>
             {
@@ -273,28 +268,12 @@ namespace Torch
                 }
             }, caller);
             return ctx.Task;
-
         }
-
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Task InvokeAsync(Action action, [CallerMemberName] string caller = "")
         {
-            if (Thread.CurrentThread == MySandboxGame.Static.UpdateThread)
-            {
-                Debug.Assert(false, $"{nameof(InvokeAsync)} should not be called on the game thread.");
-                // ReSharper disable once HeuristicUnreachableCode
-                try
-                {
-                    action.Invoke();
-                    return Task.CompletedTask;
-                }
-                catch (Exception e)
-                {
-                    return Task.FromException(e);
-                }
-            }
             var ctx = new TaskCompletionSource<bool>();
             MySandboxGame.Static.Invoke(() =>
             {

--- a/Torch/TorchBase.cs
+++ b/Torch/TorchBase.cs
@@ -353,10 +353,10 @@ namespace Torch
             Log.Info($"Executing assembly: {Assembly.GetEntryAssembly().FullName}");
             Log.Info($"Executing directory: {AppDomain.CurrentDomain.BaseDirectory}");
 
+            Managers.GetManager<PluginManager>().LoadPlugins();
             Game = new VRageGame(this, TweakGameSettings, SteamAppName, SteamAppId, Config.InstancePath, RunArgs);
             if (!Game.WaitFor(VRageGame.GameState.Stopped, TimeSpan.FromMinutes(5)))
                 Log.Warn("Failed to wait for game to be initialized");
-            Managers.GetManager<PluginManager>().LoadPlugins();
             Managers.Attach();
             _init = true;
 

--- a/Torch/VRageGame.cs
+++ b/Torch/VRageGame.cs
@@ -28,6 +28,7 @@ using VRage.FileSystem;
 using VRage.Game;
 using VRage.Game.SessionComponents;
 using VRage.GameServices;
+using VRage.Network;
 using VRage.Plugins;
 using VRage.Steam;
 using VRage.Utils;
@@ -53,6 +54,10 @@ namespace Torch
 
         [ReflectedMethod(Name = "Unload", TypeName = "Sandbox.Game.Audio.MyMusicController, Sandbox.Game")]
         private static readonly Action<object> _musicControllerUnload;
+
+//        [ReflectedGetter(Name = "UpdateLayerDescriptors", Type = typeof(MyReplicationServer))]
+//        private static readonly Func<MyReplicationServer.UpdateLayerDesc[]> _layerSettings;
+
 #pragma warning restore 649
 
         private readonly TorchBase _torch;
@@ -194,6 +199,9 @@ namespace Torch
                 MyRenderProxy.GetRenderProfiler().SetAutocommit(false);
                 MyRenderProxy.GetRenderProfiler().InitMemoryHack("MainEntryPoint");
             }
+
+//            var layers = _layerSettings();
+//            layers[layers.Length - 1].Radius *= 4;
 
             _game = new SpaceEngineersGame(_runArgs);
         }


### PR DESCRIPTION
- Write errors in Keen's logger to Torch's log
- Fix issue with removing handlers from an event list
- Move dynamic method compilation to a utility method
- Extra debug info
- Field/proprty getters/setters now use IL generation directly (you can now use them to set readonly fields)
- Change plugins to run Init before VRageGame is created
- Commented out replication layer adjustment