### PR TITLE
Wrap the plugin controls around a ScrollViewer

### DIFF
--- a/Torch.Server/Views/PluginsControl.xaml
+++ b/Torch.Server/Views/PluginsControl.xaml
@@ -28,7 +28,9 @@
             </ListView>
             <Button Grid.Row="1" Content="Open Folder" Margin="3" DockPanel.Dock="Bottom" Click="OpenFolder_OnClick"/>
         </Grid>
-        <Frame Grid.Column="1" NavigationUIVisibility="Hidden" Content="{Binding SelectedPlugin.Control}"/>
+        <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" Margin="3">
+            <Frame NavigationUIVisibility="Hidden" Content="{Binding SelectedPlugin.Control}"/>
+        </ScrollViewer>
     </Grid>
 </UserControl>
 


### PR DESCRIPTION
So plugin authors don't have to worry about controls drawing out of the
window, wrap the plugin in a ScrollViewer, which will automatically add
a scroll bar if needed.