### PR TITLE
Fixed [Theme Bug] #226 / Fixed Crash when plugin has no UI

### DIFF
--- a/Torch.Server/ViewModels/PluginViewModel.cs
+++ b/Torch.Server/ViewModels/PluginViewModel.cs
@@ -32,6 +32,9 @@ namespace Torch.Server.ViewModels
 
         public void UpdateResourceDict(ResourceDictionary dictionary)
         {
+            if (this.Control == null)
+                return;
+
             this.Control.Resources.MergedDictionaries.Clear();
             this.Control.Resources.MergedDictionaries.Add(dictionary);
         }

--- a/Torch.Server/Views/TorchUI.xaml
+++ b/Torch.Server/Views/TorchUI.xaml
@@ -63,7 +63,7 @@
         </StackPanel>
         <TabControl Grid.Row="2" Height="Auto" x:Name="TabControl" Margin="5,10,5,5">
             <TabItem Header="Log">
-                <RichTextBox x:Name="ConsoleText" VerticalScrollBarVisibility="Visible" FontFamily="Consolas"/>
+                <RichTextBox x:Name="ConsoleText" VerticalScrollBarVisibility="Visible" FontFamily="Consolas" IsReadOnly="True"/>
             </TabItem>
             <TabItem Header="Configuration">
                 <Grid IsEnabled="{Binding CanRun}">


### PR DESCRIPTION
#226 Fixed, set log to readonly
Fixed Crash when plugin has no UI
