### PR TITLE
Fixed #364

### DIFF
--- a/Torch.Server/Views/Converters/ModToIdConverter.cs
+++ b/Torch.Server/Views/Converters/ModToIdConverter.cs
@@ -32,7 +32,7 @@ namespace Torch.Server.Views.Converters
         {
             //if (targetType != typeof(int))
             //    throw new NotSupportedException("ModToIdConverter can only convert mods into int values or vise versa!");
-            if (values[0] is ModItemInfo mod || values[1] is MtObservableList<ModItemInfo> modList)
+            if (values[0] is ModItemInfo mod && values[1] is MtObservableList<ModItemInfo> modList)
             {
                 return modList.IndexOf(mod);
             }

--- a/Torch.Server/Views/Converters/ModToIdConverter.cs
+++ b/Torch.Server/Views/Converters/ModToIdConverter.cs
@@ -32,15 +32,13 @@ namespace Torch.Server.Views.Converters
         {
             //if (targetType != typeof(int))
             //    throw new NotSupportedException("ModToIdConverter can only convert mods into int values or vise versa!");
-            if (values[0].GetType() != typeof(ModItemInfo) || values[1].GetType() != typeof(MtObservableList<ModItemInfo>))
+            if (values[0] is ModItemInfo mod || values[1] is MtObservableList<ModItemInfo> modList)
             {
-                return null;
+                return modList.IndexOf(mod);
             }
             else
             {
-                var mod = (ModItemInfo) values[0];
-                var theModList = (MtObservableList<ModItemInfo>) values[1];
-                return theModList.IndexOf(mod);
+                return null;
             }
         }
 

--- a/Torch.Server/Views/Converters/ModToIdConverter.cs
+++ b/Torch.Server/Views/Converters/ModToIdConverter.cs
@@ -32,9 +32,16 @@ namespace Torch.Server.Views.Converters
         {
             //if (targetType != typeof(int))
             //    throw new NotSupportedException("ModToIdConverter can only convert mods into int values or vise versa!");
-            var mod = (ModItemInfo) values[0];
-            var theModList = (MtObservableList<ModItemInfo>) values[1];
-            return theModList.IndexOf(mod);
+            if (values[0].GetType() != typeof(ModItemInfo) || values[1].GetType() != typeof(MtObservableList<ModItemInfo>))
+            {
+                return null;
+            }
+            else
+            {
+                var mod = (ModItemInfo) values[0];
+                var theModList = (MtObservableList<ModItemInfo>) values[1];
+                return theModList.IndexOf(mod);
+            }
         }
 
         /// <summary>

--- a/Torch.Server/Views/ModListControl.xaml.cs
+++ b/Torch.Server/Views/ModListControl.xaml.cs
@@ -205,9 +205,9 @@ namespace Torch.Server.Views
             {
                 _hasOrderChanged = true;
                 var modList = (MtObservableList<ModItemInfo>)DataContext;
-                //modList.Move(modList.IndexOf(_draggedMod), modList.IndexOf(targetMod));
-                modList.RemoveAt(modList.IndexOf(_draggedMod));
-                modList.Insert(modList.IndexOf(targetMod), _draggedMod);
+                modList.Move(modList.IndexOf(targetMod), _draggedMod);
+                //modList.RemoveAt(modList.IndexOf(_draggedMod));
+                //modList.Insert(modList.IndexOf(targetMod), _draggedMod);
                 ModList.Items.Refresh();
                 ModList.SelectedItem = _draggedMod;
             }

--- a/Torch/Collections/MtObservableList.cs
+++ b/Torch/Collections/MtObservableList.cs
@@ -189,5 +189,15 @@ namespace Torch.Collections
 
         /// <inheritdoc/>
         bool IList.IsFixedSize => false;
+        
+        /// <inheritdoc/>
+        public void Move(int newIndex, object value)
+        {
+            if (value is T t)
+            {
+                base.Remove(t);
+            }
+            Insert(newIndex, (T)value);
+        }
     }
 }


### PR DESCRIPTION
The cause of this issue was because of these steps.
1. The list couldn't be dragged downward thus returning null to ModToIdConverter
2. The list was unable to insert the value at an index that was changed.
3. The length of the index when dragging becomes 1 if the list is 2
4. Since the length was 1 it would try to insert the value at index 1 (length of 2)

This has been tested by me, someone should try it as well.