### PR TITLE
Assert option and other fixes

### DIFF
--- a/Torch.Server/TorchConfig.cs
+++ b/Torch.Server/TorchConfig.cs
@@ -120,6 +120,9 @@ namespace Torch.Server
         [Arg("testplugin", "Path to a plugin to debug. For development use only.")]
         public string TestPlugin { get; set; }
 
+        [Arg("asserts", "Enable Keen's assert logging.")]
+        public bool EnableAsserts { get; set; } = false;
+
         [XmlIgnore]
         private string _path;
 

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -55,6 +55,7 @@ namespace Torch.Server
         /// <inheritdoc />
        public TorchServer(TorchConfig config = null)
         {
+            
             DedicatedInstance = new InstanceManager(this);
             AddManager(DedicatedInstance);
             AddManager(new EntityControlManager(this));
@@ -63,6 +64,9 @@ namespace Torch.Server
 
             var sessionManager = Managers.GetManager<ITorchSessionManager>();
             sessionManager.AddFactory(x => new MultiplayerManagerDedicated(this));
+            
+            if (!((TorchConfig)Config).EnableAsserts)
+                MyDebug.Listeners.Clear();
         }
         
         public bool HasRun { get => _hasRun; set => SetValue(ref _hasRun, value); }

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -53,9 +53,8 @@ namespace Torch.Server
         internal bool FatalException { get; set; }
 
         /// <inheritdoc />
-       public TorchServer(TorchConfig config = null)
+        public TorchServer(TorchConfig config = null)
         {
-            
             DedicatedInstance = new InstanceManager(this);
             AddManager(DedicatedInstance);
             AddManager(new EntityControlManager(this));
@@ -65,6 +64,8 @@ namespace Torch.Server
             var sessionManager = Managers.GetManager<ITorchSessionManager>();
             sessionManager.AddFactory(x => new MultiplayerManagerDedicated(this));
             
+            // Needs to be done at some point after MyVRageWindows.Init
+            // where the debug listeners are registered
             if (!((TorchConfig)Config).EnableAsserts)
                 MyDebug.Listeners.Clear();
         }

--- a/Torch/Patches/KeenLogPatch.cs
+++ b/Torch/Patches/KeenLogPatch.cs
@@ -11,7 +11,7 @@ using Torch.Managers.PatchManager;
 using Torch.Utils;
 using VRage.Utils;
 
-namespace Torch.Managers
+namespace Torch.Patches
 {
     [PatchShim]
     internal static class KeenLogPatch

--- a/Torch/Torch.csproj
+++ b/Torch/Torch.csproj
@@ -217,7 +217,6 @@
     <Compile Include="Event\EventList.cs" />
     <Compile Include="Event\EventManager.cs" />
     <Compile Include="Event\IEventList.cs" />
-    <Compile Include="Managers\KeenLogPatch.cs" />
     <Compile Include="Managers\PatchManager\AssemblyMemory.cs" />
     <Compile Include="Managers\PatchManager\DecoratedMethod.cs" />
     <Compile Include="Managers\PatchManager\EmitExtensions.cs" />
@@ -244,6 +243,7 @@
     <Compile Include="MySteamServiceWrapper.cs" />
     <Compile Include="Patches\GameAnalyticsPatch.cs" />
     <Compile Include="Patches\GameStatePatchShim.cs" />
+    <Compile Include="Patches\KeenLogPatch.cs" />
     <Compile Include="Patches\ObjectFactoryInitPatch.cs" />
     <Compile Include="Patches\PhysicsMemoryPatch.cs" />
     <Compile Include="Patches\SessionDownloadPatch.cs" />

--- a/Torch/VRageGame.cs
+++ b/Torch/VRageGame.cs
@@ -153,7 +153,6 @@ namespace Torch
             MySessionComponentExtDebug.ForceDisable = true;
             MyPerGameSettings.SendLogToKeen = false;
             // SpaceEngineersGame.SetupAnalytics();
-            MySandboxGame.InitMultithreading();
 
             MyFileSystem.ExePath = Path.GetDirectoryName(typeof(SpaceEngineersGame).Assembly.Location);
 
@@ -161,6 +160,7 @@ namespace Torch
 
             MyFileSystem.Reset();
             MyInitializer.InvokeBeforeRun(_appSteamId, _appName, _userDataPath);
+            MySandboxGame.InitMultithreading();
             // MyInitializer.InitCheckSum();
 
 


### PR DESCRIPTION
Disables assert logging by default and adds an <EnableAsserts> option in Torch.cfg to turn them back on.