### PR TITLE
InfluxDB.Client Integration for Server Health Monitoring

### DIFF
--- a/Torch.Server/InfluxDb/ConfigUtils.cs
+++ b/Torch.Server/InfluxDb/ConfigUtils.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Xml.Serialization;
+using NLog;
+
+namespace Torch.Server.InfluxDb
+{
+    /// <summary>
+    /// Helper functions to serialize/deserialize config files
+    /// </summary>
+    internal static class ConfigUtils
+    {
+        static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// Load a config file at given location.
+        /// </summary>
+        /// <remarks>Search path will be relative to the application bin directory.</remarks>
+        /// <remarks>If a config file doesn't exist at specified path,
+        /// a new config file will be created at the path using given default config,
+        /// and the function will return the default config.</remarks>
+        /// <param name="fileName">Name of the config file to deserialize.</param>
+        /// <param name="defaultConfig">Default config to save in the disk if a config is not found at specified path.</param>
+        /// <typeparam name="T">Type of the config.</typeparam>
+        /// <returns>Config deserialized from specified config file. If file is not found, `defaultConfig` will be returned.</returns>
+        public static T LoadConfigFile<T>(string fileName, T defaultConfig)
+        {
+            var configPath = Path.Combine(Directory.GetCurrentDirectory(), fileName);
+
+            var configSerializer = new XmlSerializer(typeof(T));
+
+            if (!File.Exists(fileName))
+            {
+                _logger.Info($"Generating default config at {configPath}");
+
+                using (var file = File.Create(configPath))
+                {
+                    configSerializer.Serialize(file, defaultConfig);
+                }
+
+                return defaultConfig;
+            }
+
+            _logger.Info($"Loading config {configPath}");
+
+            using (var file = File.OpenRead(configPath))
+            {
+                return (T) configSerializer.Deserialize(file);
+            }
+        }
+    }
+}

--- a/Torch.Server/InfluxDb/InfluxDbClient.cs
+++ b/Torch.Server/InfluxDb/InfluxDbClient.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Writes;
+
+namespace Torch.Server.InfluxDb
+{
+    /// <summary>
+    /// Wrap the endpoint of the InfluxDB instance.
+    /// </summary>
+    public class InfluxDbClient : IDisposable
+    {
+        readonly InfluxDbConfig _config;
+        readonly InfluxDBClient _influxClient;
+        readonly WriteApi _writeApi;
+
+        /// <summary>
+        /// Instantiate class.
+        /// </summary>
+        /// <param name="config">Config for this instance.</param>
+        internal InfluxDbClient(InfluxDbConfig config)
+        {
+            _config = config;
+
+            _influxClient?.Dispose();
+            _writeApi?.Dispose();
+
+            _influxClient = InfluxDBClientFactory.Create(
+                config.DbHost,
+                config.Token.ToCharArray());
+
+            _writeApi = _influxClient.GetWriteApi();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _influxClient.Dispose();
+            _writeApi.Dispose();
+        }
+
+        /// <summary>
+        /// Instantiate a new PointData object with some properties set for convenience.
+        /// </summary>
+        /// <remarks>Timestamp will be set, but can be overwritten.</remarks>
+        /// <param name="measurement">Measurement to write this point to.</param>
+        /// <returns>New PointData object.</returns>
+        public PointData MakePointIn(string measurement)
+        {
+            // Note: UTC time is used
+            var timestamp = DateTime.UtcNow;
+
+            return PointData
+                .Measurement(measurement)
+                .Timestamp(timestamp, WritePrecision.S);
+        }
+
+        /// <summary>
+        /// Write given points to the InfluxDB instance.
+        /// </summary>
+        /// <remarks>Will NOT throw or log errors when failed. Check the database console to find any issues.</remarks>
+        /// <param name="points">List of points to write to the DB instance.</param>
+        public void WritePoints(params PointData[] points)
+        {
+            _writeApi.WritePoints(_config.Bucket, _config.Organization, points);
+        }
+    }
+}

--- a/Torch.Server/InfluxDb/InfluxDbConfig.cs
+++ b/Torch.Server/InfluxDb/InfluxDbConfig.cs
@@ -1,0 +1,45 @@
+﻿using System.Xml.Serialization;
+
+namespace Torch.Server.InfluxDb
+{
+    /// <summary>
+    /// Configuration for InfluxDB integration.
+    /// </summary>
+    public class InfluxDbConfig
+    {
+        /// <summary>
+        /// Endpoint IP:port of the InfluxDB instance.
+        /// </summary>
+        [XmlElement]
+        public string DbHost { get; set; }
+
+        /// <summary>
+        /// Bucket name of the InfluxDB instance.
+        /// </summary>
+        [XmlElement]
+        public string Bucket { get; set; }
+
+        /// <summary>
+        /// Organization name of the InfluxDB instance.
+        /// </summary>
+        [XmlElement]
+        public string Organization { get; set; }
+
+        /// <summary>
+        /// Token to authenticate into the InfluxDB instance (if any).
+        /// </summary>
+        [XmlElement]
+        public string Token { get; set; }
+        
+        /// <summary>
+        /// Default configuration.
+        /// </summary>
+        public static InfluxDbConfig Default => new InfluxDbConfig
+        {
+            DbHost = "http://localhost:8086",
+            Bucket = "test",
+            Organization = "foo",
+            Token = "token",
+        };
+    }
+}

--- a/Torch.Server/InfluxDb/InfluxDbManager.cs
+++ b/Torch.Server/InfluxDb/InfluxDbManager.cs
@@ -1,0 +1,38 @@
+﻿using Torch.API;
+using Torch.Managers;
+
+namespace Torch.Server.InfluxDb
+{
+    /// <summary>
+    /// Set up and manage lifecycle of the InfluxDB binding.
+    /// </summary>
+    public sealed class InfluxDbManager : Manager
+    {
+        const string ConfigName = "InfluxDbConfig.cfg";
+
+        /// <inheritdoc/>
+        internal InfluxDbManager(ITorchBase torchInstance) : base(torchInstance)
+        {
+        }
+
+        /// <summary>
+        /// InfluxDB instance binder object.
+        /// </summary>
+        public InfluxDbClient Client { get; private set; }
+
+        /// <inheritdoc/>
+        public override void Attach()
+        {
+            var config = ConfigUtils.LoadConfigFile(ConfigName, InfluxDbConfig.Default);
+
+            Client?.Dispose();
+            Client = new InfluxDbClient(config);
+        }
+
+        /// <inheritdoc/>
+        public override void Detach()
+        {
+            Client?.Dispose();
+        }
+    }
+}

--- a/Torch.Server/Torch.Server.csproj
+++ b/Torch.Server/Torch.Server.csproj
@@ -63,16 +63,36 @@
     <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
     </Reference>
+    <Reference Include="CsvHelper, Version=15.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823">
+      <HintPath>..\packages\CsvHelper.15.0.4\lib\net45\CsvHelper.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="HavokWrapper, Version=1.0.6051.28726, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\GameBinaries\HavokWrapper.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="InfluxDB.Client, Version=1.13.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f">
+      <HintPath>..\packages\InfluxDB.Client.1.13.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="InfluxDB.Client.Core, Version=1.13.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f">
+      <HintPath>..\packages\InfluxDB.Client.Core.1.13.0\lib\netstandard2.0\InfluxDB.Client.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="JsonSubTypes, Version=1.5.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\JsonSubTypes.1.5.2\lib\net46\JsonSubTypes.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MahApps.Metro, Version=1.6.1.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.6.1\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Markdown.Xaml, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdown.Xaml.1.0.0\lib\net45\Markdown.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -83,6 +103,18 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\GameBinaries\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=3.1.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.ObjectPool.3.1.4\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\packages\Microsoft.Net.Http.Headers.2.1.1\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Win32.Registry, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -100,8 +132,20 @@
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NodaTime, Version=2.4.1.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1">
+      <HintPath>..\packages\NodaTime.2.4.1\lib\net45\NodaTime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NodaTime.Serialization.JsonNet, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1">
+      <HintPath>..\packages\NodaTime.Serialization.JsonNet.2.0.0\lib\net45\NodaTime.Serialization.JsonNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=106.6.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75">
+      <HintPath>..\packages\RestSharp.106.6.10\lib\net452\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Sandbox.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -137,25 +181,93 @@
       <HintPath>..\GameBinaries\Steamworks.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Configuration.ConfigurationManager, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Configuration.ConfigurationManager.4.5.0\lib\net461\System.Configuration.ConfigurationManager.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive, Version=4.1.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263">
+      <HintPath>..\packages\System.Reactive.4.1.2\lib\net46\System.Reactive.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Permissions, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Security.Permissions.4.5.0\lib\net461\System.Security.Permissions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\System.Windows.Interactivity.dll</HintPath>
@@ -165,7 +277,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
@@ -242,6 +353,10 @@
     </Compile>
     <Compile Include="Commands\WhitelistCommands.cs" />
     <Compile Include="FlowDocumentTarget.cs" />
+    <Compile Include="InfluxDb\ConfigUtils.cs" />
+    <Compile Include="InfluxDb\InfluxDbClient.cs" />
+    <Compile Include="InfluxDb\InfluxDbConfig.cs" />
+    <Compile Include="InfluxDb\InfluxDbManager.cs" />
     <Compile Include="ListBoxExtensions.cs" />
     <Compile Include="Managers\EntityControlManager.cs" />
     <Compile Include="Managers\MultiplayerManagerDedicated.cs" />
@@ -520,7 +635,6 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\TransformOnBuild.targets" />
   <PropertyGroup>

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -21,6 +21,7 @@ using Torch.Commands;
 using Torch.Mod;
 using Torch.Mod.Messages;
 using Torch.Server.Commands;
+using Torch.Server.InfluxDb;
 using Torch.Server.Managers;
 using Torch.Utils;
 using VRage;
@@ -62,6 +63,7 @@ namespace Torch.Server
             AddManager(DedicatedInstance);
             AddManager(new EntityControlManager(this));
             AddManager(new RemoteAPIManager(this));
+            AddManager(new InfluxDbManager(this));
             Config = config ?? new TorchConfig();
 
             var sessionManager = Managers.GetManager<ITorchSessionManager>();

--- a/Torch.Server/packages.config
+++ b/Torch.Server/packages.config
@@ -1,15 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ControlzEx" version="3.0.2.4" targetFramework="net461" />
+  <package id="CsvHelper" version="15.0.4" targetFramework="net461" />
+  <package id="InfluxDB.Client" version="1.13.0" targetFramework="net461" />
+  <package id="InfluxDB.Client.Core" version="1.13.0" targetFramework="net461" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net461" />
+  <package id="System.Configuration.ConfigurationManager" version="4.5.0" targetFramework="net461" />
+  <package id="System.Reactive" version="4.1.2" targetFramework="net461" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net461" />
+  <package id="System.Security.Permissions" version="4.5.0" targetFramework="net461" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net461" />
+  <package id="JsonSubTypes" version="1.5.2" targetFramework="net461" />
   <package id="MahApps.Metro" version="1.6.1" targetFramework="net461" />
   <package id="Markdown.Xaml" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.ObjectPool" version="3.1.4" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net461" />
+  <package id="Microsoft.Net.Http.Headers" version="2.1.1" targetFramework="net461" />
   <package id="Microsoft.Win32.Registry" version="4.4.0" targetFramework="net461" />
   <package id="Mono.TextTransform" version="1.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="NLog" version="4.4.12" targetFramework="net461" />
+  <package id="NodaTime" version="2.4.1" targetFramework="net461" />
+  <package id="NodaTime.Serialization.JsonNet" version="2.0.0" targetFramework="net461" />
+  <package id="RestSharp" version="106.6.10" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="protobuf-net" version="2.4.0" targetFramework="net461" />
   <package id="SteamKit2" version="2.1.0" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net461" />
-  <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net461" />
-  <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR adds dependency to [`InfluxDB.Client`](https://github.com/influxdata/influxdb-client-csharp) and some bridge classes for easy consumption by plugins such as [TorchMonitor](https://github.com/HnZGaming/TorchMonitor).

![Screenshot 2020-11-02 025502](https://user-images.githubusercontent.com/5270319/97810390-d2ba9180-1cb6-11eb-9522-ea8eea8a333b.png)

**Why InfluxDB?**

1. Fank has made [a monitoring program with InfluxDB](https://www.reddit.com/r/spaceengineers/comments/98mgn1/monitoring_for_dedicated_servers/) which had familiarized SE admin community with this library.
2. InfluxDB is a MIT-licensed open-sourced project, with an active body of developers, users and online resource. 
3. Fairly easy to get going and scale later.

Alternative choice of database: Elasticsearch can handle more types and schemes of data. Please ask Kontu's team. Our Torch fork does have Elasticsearch integrated as well (not included in this PR).

**Why Integrate Database to Torch?**

The admin community's strong interest toward a nice-looking monitoring dashboard. Easy access to database will be the first step forward to everyone's dream. Higher standard of understanding to the game and players shall enlighten our minds...🧙‍♂️