### PR TITLE
MyDefinitionId.ToString fix

### DIFF
--- a/Torch.Server/Torch.Server.csproj
+++ b/Torch.Server/Torch.Server.csproj
@@ -530,6 +530,9 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tools\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\TransformOnBuild.targets" />
   <PropertyGroup>

--- a/Torch.Server/TorchConfig.cs
+++ b/Torch.Server/TorchConfig.cs
@@ -8,6 +8,7 @@ using System.Xml.Serialization;
 using Newtonsoft.Json;
 using NLog;
 using Torch.API;
+using Torch.Patches;
 using Torch.Views;
 using VRage.Game;
 
@@ -45,6 +46,7 @@ namespace Torch.Server
         private bool _sendLogsToKeen;
         private bool _deleteMiniDumps = true;
         private string _loginToken;
+        private bool _defIdFix = true;
 
 
         /// <inheritdoc />
@@ -184,6 +186,18 @@ public string LastUsedTheme { get; set; } = "Torch Theme";
         [Arg("logintoken", "Steam GSLT")]
         [Display(Name = "Login Token", Description = "Steam GSLT (can be used if you have dynamic ip)", GroupName = "Server")]
         public string LoginToken { get => _loginToken; set => Set(value, ref _loginToken); }
+
+        [Arg("defidfix", "MyDefinitionId.ToString fix (performance, deadlock)")]
+        [Display(Name = "Login Token", Description = "MyDefinitionId.ToString fix (performance, deadlock)", GroupName = "Server")]
+        public bool DefIdFix
+        {
+            get => _defIdFix;
+            set
+            {
+                Set(value, ref _defIdFix);
+                MyDefinitionIdToStringPatch.Enabled = value;
+            }
+        }
 
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Torch.Server/TorchConfig.cs
+++ b/Torch.Server/TorchConfig.cs
@@ -8,7 +8,6 @@ using System.Xml.Serialization;
 using Newtonsoft.Json;
 using NLog;
 using Torch.API;
-using Torch.Patches;
 using Torch.Views;
 using VRage.Game;
 
@@ -46,7 +45,6 @@ namespace Torch.Server
         private bool _sendLogsToKeen;
         private bool _deleteMiniDumps = true;
         private string _loginToken;
-        private bool _defIdFix = true;
 
 
         /// <inheritdoc />
@@ -186,18 +184,6 @@ public string LastUsedTheme { get; set; } = "Torch Theme";
         [Arg("logintoken", "Steam GSLT")]
         [Display(Name = "Login Token", Description = "Steam GSLT (can be used if you have dynamic ip)", GroupName = "Server")]
         public string LoginToken { get => _loginToken; set => Set(value, ref _loginToken); }
-
-        [Arg("defidfix", "MyDefinitionId.ToString fix (performance, deadlock)")]
-        [Display(Name = "Login Token", Description = "MyDefinitionId.ToString fix (performance, deadlock)", GroupName = "Server")]
-        public bool DefIdFix
-        {
-            get => _defIdFix;
-            set
-            {
-                Set(value, ref _defIdFix);
-                MyDefinitionIdToStringPatch.Enabled = value;
-            }
-        }
 
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -22,6 +22,7 @@ using Torch.Commands;
 using Torch.Managers.PatchManager;
 using Torch.Mod;
 using Torch.Mod.Messages;
+using Torch.Patches;
 using Torch.Server.Commands;
 using Torch.Server.Managers;
 using Torch.Utils;
@@ -71,8 +72,12 @@ namespace Torch.Server
             
             // Needs to be done at some point after MyVRageWindows.Init
             // where the debug listeners are registered
-            if (!((TorchConfig)Config).EnableAsserts)
+            var torchConfig = (TorchConfig)Config;
+            if (!torchConfig.EnableAsserts)
                 MyDebug.Listeners.Clear();
+
+            MyDefinitionIdToStringPatch.Enabled = torchConfig.DefIdFix;
+            
             _simUpdateTimer.Elapsed += SimUpdateElapsed;
             _simUpdateTimer.Start();
         }
@@ -265,6 +270,8 @@ namespace Torch.Server
                 _watchdog = new Timer(CheckServerResponding, this, TimeSpan.Zero,
                     TimeSpan.FromSeconds(Config.TickTimeout));
             }
+            
+            MyDefinitionIdToStringPatch.Update(MySandboxGame.Static.FrameTimeTicks);
         }
 
         #region Freeze Detection

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -266,8 +266,6 @@ namespace Torch.Server
                 _watchdog = new Timer(CheckServerResponding, this, TimeSpan.Zero,
                     TimeSpan.FromSeconds(Config.TickTimeout));
             }
-            
-            MyDefinitionIdToStringPatch.Update(MySandboxGame.Static.FrameTimeTicks);
         }
 
         #region Freeze Detection

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -72,12 +72,8 @@ namespace Torch.Server
             
             // Needs to be done at some point after MyVRageWindows.Init
             // where the debug listeners are registered
-            var torchConfig = (TorchConfig)Config;
-            if (!torchConfig.EnableAsserts)
+            if (!((TorchConfig)Config).EnableAsserts)
                 MyDebug.Listeners.Clear();
-
-            MyDefinitionIdToStringPatch.Enabled = torchConfig.DefIdFix;
-            
             _simUpdateTimer.Elapsed += SimUpdateElapsed;
             _simUpdateTimer.Start();
         }

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -31,12 +31,12 @@ namespace Torch.Patches
         private static readonly Logger _log = LogManager.GetCurrentClassLogger();
 #endif
 
-        public static void Update(long uptime)
+        public static void Update(long ticks)
         {
-            if (uptime < nextFill)
+            if (ticks < nextFill)
                 return;
 
-            nextFill = uptime + FillPeriod;
+            nextFill = ticks + FillPeriod;
         
 #if DEBUG
             _log.Info($"{nameof(MyDefinitionIdToStringPatch)}: {CacheReport}");

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -1,0 +1,109 @@
+// Caching ported from Performance Improvements 1.10.5
+// Reasons:
+// https://support.keenswh.com/spaceengineers/pc/topic/27997-servers-deadlocked-on-load
+// https://support.keenswh.com/spaceengineers/pc/topic/24210-performance-pre-calculate-or-cache-mydefinitionid-tostring-results
+
+#if DEBUG
+// Uncomment this to enable the verification of cached results to the original call (disables caching!)
+// #define VERIFY_RESULT
+#endif
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using NLog;
+using VRage.Game;
+using Torch.Managers.PatchManager;
+using Torch.Utils.Cache;
+
+namespace Torch.Patches
+{
+    [PatchShim]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public static class MyDefinitionIdToStringPatch
+    {
+        private static bool enabled = true;
+
+        public static bool Enabled
+        {
+            get => Enabled;
+            set
+            {
+                enabled = value;
+                if (!enabled)
+                    Cache.Clear();
+            }
+        }
+
+        private static readonly CacheForever<long, string> Cache = new CacheForever<long, string>();
+        private static long nextFill;
+        private const long FillPeriod = 37 * 60;  // frames
+
+#if DEBUG
+        private static string CacheReport => $"{Cache.ImmutableReport} | {Cache.Report}";
+        private static readonly Logger _log = LogManager.GetCurrentClassLogger();
+#endif
+
+        public static void Update(long uptime)
+        {
+            if (!enabled || uptime < nextFill)
+                return;
+
+            nextFill = uptime + FillPeriod;
+        
+#if DEBUG
+            _log.Info($"{nameof(MyDefinitionIdToStringPatch)}: {CacheReport}");
+#endif
+
+            Cache.FillImmutableCache();
+        }
+        
+        // ReSharper disable once UnusedMember.Global
+        internal static void Patch(PatchContext context)
+        {
+            context.GetPattern(typeof(MyDefinitionId).GetMethod(nameof(MyDefinitionId.ToString))).Prefixes.Add(typeof(MyDefinitionIdToStringPatch).GetMethod(nameof(MyDefinitionIdToStringPrefix), BindingFlags.Static | BindingFlags.NonPublic));
+        }
+        
+        // ReSharper disable once UnusedMember.Local
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool MyDefinitionIdToStringPrefix(MyDefinitionId __instance, ref string __result)
+        {
+            if (!enabled)
+                return true;
+
+            if (Cache.TryGetValue(__instance.GetHashCodeLong(), out __result))
+            {
+#if DEBUG && VERIFY_RESULT
+                var expectedName = Format(__instance);
+                Debug.Assert(__result == expectedName);
+#endif
+                return false;
+            }
+
+            var result = Format(__instance);
+            Cache.Store(__instance.GetHashCodeLong(), result);
+
+            __result = result;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string Format(MyDefinitionId definitionId)
+        {
+            const string DefinitionNull = "(null)";
+
+            var typeId = definitionId.TypeId;
+            var typeName = typeId.IsNull ? DefinitionNull : typeId.ToString();
+
+            var subtypeName = definitionId.SubtypeName;
+            if (string.IsNullOrEmpty(subtypeName))
+                subtypeName = DefinitionNull;
+
+            var sb = ObjectPools.StringBuilder.Get(typeName.Length + 1 + subtypeName.Length);
+            var text = sb.Append(typeName).Append('/').Append(subtypeName).ToString();
+            ObjectPools.StringBuilder.Return(sb);
+
+            return text;
+        }
+    }
+}

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -3,10 +3,11 @@
 // https://support.keenswh.com/spaceengineers/pc/topic/27997-servers-deadlocked-on-load
 // https://support.keenswh.com/spaceengineers/pc/topic/24210-performance-pre-calculate-or-cache-mydefinitionid-tostring-results
 
-#if DEBUG
 // Uncomment this to enable the verification that all formatting actually matches the first one (effectively disables caching)
 // #define VERIFY_RESULT
-#endif
+
+// Uncomment to enable logging statistics
+#define LOG_STATS
 
 using System;
 using System.Diagnostics;
@@ -26,11 +27,11 @@ namespace Torch.Patches
     {
         private static readonly CacheForever<long, string> Cache = new CacheForever<long, string>();
         private static long nextFill;
-        private const long FillPeriod = 37 * 60;  // frames
+        private const long FillPeriod = 37 * 60; // frames
 
-#if DEBUG
-        private static string CacheReport => $"1-RO: {Cache.ImmutableReport} | 2-RW: {Cache.Report}";
+#if LOG_STATS
         private static readonly Logger _log = LogManager.GetCurrentClassLogger();
+        private static string CacheReport => $"1-RO: {Cache.ImmutableReport} | 2-RW: {Cache.Report}";
 #endif
 
         public static void Update(long ticks)
@@ -39,26 +40,26 @@ namespace Torch.Patches
                 return;
 
             nextFill = ticks + FillPeriod;
-        
-#if DEBUG
+
+#if LOG_STATS
             _log.Info($"{nameof(MyDefinitionIdToStringPatch)}: {CacheReport}");
 #endif
 
             Cache.FillImmutableCache();
         }
-        
+
         // ReSharper disable once UnusedMember.Global
         internal static void Patch(PatchContext context)
         {
-            var targetMethod = typeof(MyDefinitionId).GetMethod(nameof(MyDefinitionId.ToString));
+            var targetMethod = typeof(MyDefinitionId).GetMethod(nameof(MyDefinitionId.ToString), BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
             Debug.Assert(targetMethod != null);
-            
+
             var patchMethod = typeof(MyDefinitionIdToStringPatch).GetMethod(nameof(ToStringPrefix), BindingFlags.Static | BindingFlags.NonPublic);
             Debug.Assert(patchMethod != null);
-            
+
             context.GetPattern(targetMethod).Prefixes.Add(patchMethod);
         }
-        
+
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable once RedundantAssignment
         private static bool ToStringPrefix(MyDefinitionId __instance, ref string __result)
@@ -67,7 +68,7 @@ namespace Torch.Patches
             {
                 if (Cache.TryGetValue(__instance.GetHashCodeLong(), out __result))
                 {
-#if DEBUG && VERIFY_RESULT
+#if VERIFY_RESULT
                 var expectedName = Format(__instance);
                 Debug.Assert(__result == expectedName);
 #endif
@@ -83,6 +84,7 @@ namespace Torch.Patches
             {
                 _log.Error($"{e.Message}: {e}");
             }
+
             return false;
         }
 
@@ -95,21 +97,21 @@ namespace Torch.Patches
             string subtypeName = !string.IsNullOrEmpty(definitionId.SubtypeName) ? definitionId.SubtypeName : "(null)";
             return string.Format("{0}/{1}", typeId, subtypeName);
 #endif
-            
+
             // Same with less memory allocation due to reusing StringBuilder instances
             const string DefinitionNull = "(null)";
-            
+
             var typeId = definitionId.TypeId;
             var typeName = typeId.IsNull ? DefinitionNull : typeId.ToString();
-            
+
             var subtypeName = definitionId.SubtypeName;
             if (string.IsNullOrEmpty(subtypeName))
                 subtypeName = DefinitionNull;
-            
+
             var sb = ObjectPools.StringBuilder.Get(typeName.Length + 1 + subtypeName.Length);
             var text = sb.Append(typeName).Append('/').Append(subtypeName).ToString();
             ObjectPools.StringBuilder.Return(sb);
-            
+
             return text;
         }
     }

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -31,7 +31,7 @@ namespace Torch.Patches
 
 #if LOG_STATS
         private static readonly Logger _log = LogManager.GetCurrentClassLogger();
-        private static string CacheReport => $"1-RO: {Cache.ImmutableReport} | 2-RW: {Cache.Report}";
+        private static string CacheReport => $"L1-RO: {Cache.ImmutableReport} | L2-RW: {Cache.Report}";
 #endif
 
         public static void Update(long ticks)

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -4,7 +4,7 @@
 // https://support.keenswh.com/spaceengineers/pc/topic/24210-performance-pre-calculate-or-cache-mydefinitionid-tostring-results
 
 #if DEBUG
-// Uncomment this to enable the verification of cached results to the original call (disables caching!)
+// Uncomment this to enable the verification that all formatting actually matches the first one (effectively disables caching)
 // #define VERIFY_RESULT
 #endif
 

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -52,6 +52,7 @@ namespace Torch.Patches
         }
         
         // ReSharper disable once UnusedMember.Local
+        // ReSharper disable once RedundantAssignment
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool MyDefinitionIdToStringPrefix(MyDefinitionId __instance, ref string __result)
         {

--- a/Torch/Patches/MyDefinitionIdToStringPatch.cs
+++ b/Torch/Patches/MyDefinitionIdToStringPatch.cs
@@ -53,7 +53,6 @@ namespace Torch.Patches
         
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable once RedundantAssignment
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool MyDefinitionIdToStringPrefix(MyDefinitionId __instance, ref string __result)
         {
             if (Cache.TryGetValue(__instance.GetHashCodeLong(), out __result))

--- a/Torch/Torch.csproj
+++ b/Torch/Torch.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Patches\KeenLogPatch.cs" />
     <Compile Include="Patches\MessageSizeLimitPatch.cs" />
     <Compile Include="Patches\ModsDownloadingPatch.cs" />
+    <Compile Include="Patches\MyDefinitionIdToStringPatch.cs" />
     <Compile Include="Patches\PhysicsMemoryPatch.cs" />
     <Compile Include="Patches\SessionDownloadPatch.cs" />
     <Compile Include="Patches\TorchAsyncSaving.cs" />
@@ -271,6 +272,11 @@
     <Compile Include="Managers\UpdateManager.cs" />
     <Compile Include="Persistent.cs" />
     <Compile Include="Plugins\PluginManifest.cs" />
+    <Compile Include="Utils\Cache\CacheForever.cs" />
+    <Compile Include="Utils\Cache\CacheStat.cs" />
+    <Compile Include="Utils\Cache\ObjectPools.cs" />
+    <Compile Include="Utils\Concurrent\RwLock.cs" />
+    <Compile Include="Utils\Concurrent\RwLockDictionary.cs" />
     <Compile Include="Utils\ModItemUtils.cs" />
     <Compile Include="Utils\SteamWorkshopTools\KeyValueExtensions.cs" />
     <Compile Include="Utils\MiscExtensions.cs" />

--- a/Torch/TorchBase.cs
+++ b/Torch/TorchBase.cs
@@ -435,6 +435,7 @@ namespace Torch
         public virtual void Update()
         {
             Managers.GetManager<IPluginManager>().UpdatePlugins();
+            MyDefinitionIdToStringPatch.Update(MySandboxGame.Static?.FrameTimeTicks ?? 0);
         }
 
 

--- a/Torch/Utils/Cache/CacheForever.cs
+++ b/Torch/Utils/Cache/CacheForever.cs
@@ -1,3 +1,6 @@
+// Uncomment to enable collecting statistics
+#define COLLECT_STATS
+
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Torch.Utils.Concurrent;
@@ -12,7 +15,7 @@ namespace Torch.Utils.Cache
         // Second layer mutable and synchronized cache, collecting new keys
         private readonly RwLockDictionary<TK, TV> cache = new RwLockDictionary<TK, TV>();
 
-#if DEBUG
+#if COLLECT_STATS
         private readonly CacheStat immutableStat = new CacheStat();
         private readonly CacheStat stat = new CacheStat();
         public string ImmutableReport => immutableStat.Report;
@@ -56,19 +59,19 @@ namespace Torch.Utils.Cache
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(TK key, out TV value)
         {
-#if DEBUG
+#if COLLECT_STATS
             immutableStat.CountLookup(immutableCache.Count);
 #endif
 
             if (immutableCache.TryGetValue(key, out value))
             {
-#if DEBUG
+#if COLLECT_STATS
                 immutableStat.CountHit();
 #endif
                 return true;
             }
 
-#if DEBUG
+#if COLLECT_STATS
             stat.CountLookup(cache.Count);
 #endif
 
@@ -76,7 +79,7 @@ namespace Torch.Utils.Cache
             if (cache.TryGetValue(key, out value))
             {
                 cache.FinishReading();
-#if DEBUG
+#if COLLECT_STATS
                 stat.CountHit();
 #endif
                 return true;

--- a/Torch/Utils/Cache/CacheForever.cs
+++ b/Torch/Utils/Cache/CacheForever.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Torch.Utils.Concurrent;
+
+namespace Torch.Utils.Cache
+{
+    public class CacheForever<TK, TV>
+    {
+        // First layer immutable cache, which does not need synchronization, but needs to be filled
+        private IReadOnlyDictionary<TK, TV> immutableCache = new Dictionary<TK, TV>();
+
+        // Second layer mutable and synchronized cache, collecting new keys
+        private readonly RwLockDictionary<TK, TV> cache = new RwLockDictionary<TK, TV>();
+
+#if DEBUG
+        private readonly CacheStat immutableStat = new CacheStat();
+        private readonly CacheStat stat = new CacheStat();
+        public string ImmutableReport => immutableStat.Report;
+        public string Report => stat.Report;
+#endif
+
+        public void Clear()
+        {
+            cache.BeginWriting();
+            immutableCache = new Dictionary<TK, TV>();
+            cache.Clear();
+            cache.FinishWriting();
+        }
+
+        public void FillImmutableCache()
+        {
+            if (immutableCache.Count == cache.Count)
+                return;
+
+            cache.BeginReading();
+            immutableCache = new Dictionary<TK, TV>(cache);
+            cache.FinishReading();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Store(TK key, TV value)
+        {
+            cache.BeginWriting();
+            cache[key] = value;
+            cache.FinishWriting();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Forget(TK key)
+        {
+            cache.BeginWriting();
+            cache.Remove(key);
+            cache.FinishWriting();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetValue(TK key, out TV value)
+        {
+#if DEBUG
+            immutableStat.CountLookup(immutableCache.Count);
+#endif
+
+            if (immutableCache.TryGetValue(key, out value))
+            {
+#if DEBUG
+                immutableStat.CountHit();
+#endif
+                return true;
+            }
+
+#if DEBUG
+            stat.CountLookup(cache.Count);
+#endif
+
+            cache.BeginReading();
+            if (cache.TryGetValue(key, out value))
+            {
+                cache.FinishReading();
+#if DEBUG
+                stat.CountHit();
+#endif
+                return true;
+            }
+
+            cache.FinishReading();
+            value = default;
+            return false;
+        }
+    }
+}

--- a/Torch/Utils/Cache/CacheStat.cs
+++ b/Torch/Utils/Cache/CacheStat.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Torch.Utils.Cache
+{
+    // Not thread safe, since we don't care about super exact results
+    public class CacheStat
+    {
+        private long Lookups { get; set; }
+        private long Hits { get; set; }
+        private int Size { get; set; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Reset()
+        {
+            Lookups = 0;
+            Hits = 0;
+            Size = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CountLookup(int size)
+        {
+            Size = size;
+            Lookups++;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CountHit()
+        {
+            Hits++;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Add(CacheStat source)
+        {
+            Lookups += source.Lookups;
+            Hits += source.Hits;
+            Size += source.Size;
+
+            source.Reset();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AddRange(IEnumerable<CacheStat> stats)
+        {
+            foreach (var stat in stats)
+                Add(stat);
+        }
+
+        public string Report
+        {
+            get
+            {
+                var lookups = Lookups;
+                var hits = Hits;
+                var size = Size;
+
+                if (hits > lookups)
+                    hits = lookups;
+
+                Reset();
+
+                var rate = lookups > 0 ? 100.0 * hits / lookups : 0;
+                return $"HitRate = {rate:0.000}% = {hits}/{lookups}; ItemCount = {size}";
+            }
+        }
+    }
+}

--- a/Torch/Utils/Cache/ObjectPools.cs
+++ b/Torch/Utils/Cache/ObjectPools.cs
@@ -1,0 +1,50 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using VRage.Collections;
+
+namespace Torch.Utils.Cache
+{
+    public static class ObjectPools
+    {
+        public static readonly MyConcurrentBucketPool<StringBuilder> StringBuilder = new MyConcurrentBucketPool<StringBuilder>(typeof(ObjectPools).FullName, new StringBuilderAllocator());
+
+        private class StringBuilderAllocator : IMyElementAllocator<StringBuilder>
+        {
+            private const int BucketSizeBits = 4;
+            private const int BucketSize = 1 << BucketSizeBits;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public StringBuilder Allocate(int bucketId)
+            {
+                var capacity = bucketId << BucketSizeBits;
+                return new StringBuilder(capacity, capacity + BucketSize);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Init(StringBuilder instance)
+            {
+                instance.Clear();
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Dispose(StringBuilder instance)
+            {
+                instance.Clear();
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int GetBytes(StringBuilder instance)
+            {
+                return instance.Capacity;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int GetBucketId(StringBuilder instance)
+            {
+                return instance.Capacity >> BucketSizeBits;
+            }
+
+            public bool ExplicitlyDisposeAllElements => false;
+        }
+    }
+}

--- a/Torch/Utils/Concurrent/RwLock.cs
+++ b/Torch/Utils/Concurrent/RwLock.cs
@@ -1,0 +1,81 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Torch.Utils.Concurrent
+{
+    public static class RwLock
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AcquireForReading(ref int counter)
+        {
+            var spinWait = new SpinWait();
+            var previous = counter;
+            while (previous < 0 || previous != Interlocked.CompareExchange(ref counter, previous + 1, previous))
+            {
+                spinWait.SpinOnce();
+                previous = counter;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ReleaseAfterReading(ref int counter)
+        {
+            Interlocked.Decrement(ref counter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AcquireForWriting(ref int counter)
+        {
+            var spinWait = new SpinWait();
+            while (Interlocked.CompareExchange(ref counter, -1, 0) != 0)
+            {
+                spinWait.SpinOnce();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ReleaseAfterWriting(ref int counter)
+        {
+            counter = 0;
+        }
+    }
+
+    public class RwLockCounter
+    {
+        private int counter;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquireForReading()
+        {
+            var spinWait = new SpinWait();
+            var previous = counter;
+            while (previous < 0 || previous != Interlocked.CompareExchange(ref counter, previous + 1, previous))
+            {
+                spinWait.SpinOnce();
+                previous = counter;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseAfterReading()
+        {
+            Interlocked.Decrement(ref counter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquireForWriting()
+        {
+            var spinWait = new SpinWait();
+            while (Interlocked.CompareExchange(ref counter, -1, 0) != 0)
+            {
+                spinWait.SpinOnce();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseAfterWriting()
+        {
+            counter = 0;
+        }
+    }
+}

--- a/Torch/Utils/Concurrent/RwLockDictionary.cs
+++ b/Torch/Utils/Concurrent/RwLockDictionary.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+
+namespace Torch.Utils.Concurrent
+{
+    public class RwLockDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+    {
+        private int counter;
+
+        public RwLockDictionary()
+        {
+        }
+
+        public RwLockDictionary(int capacity) : base(capacity)
+        {
+        }
+
+        public RwLockDictionary(IEqualityComparer<TKey> comparer) : base(comparer)
+        {
+        }
+
+        public RwLockDictionary(int capacity, IEqualityComparer<TKey> comparer) : base(capacity, comparer)
+        {
+        }
+
+        public RwLockDictionary(IDictionary<TKey, TValue> dictionary) : base(dictionary)
+        {
+        }
+
+        public RwLockDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) : base(dictionary, comparer)
+        {
+        }
+
+        protected RwLockDictionary(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void BeginReading()
+        {
+            RwLock.AcquireForReading(ref counter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FinishReading()
+        {
+            RwLock.ReleaseAfterReading(ref counter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void BeginWriting()
+        {
+            RwLock.AcquireForWriting(ref counter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FinishWriting()
+        {
+            RwLock.ReleaseAfterWriting(ref counter);
+        }
+    }
+}


### PR DESCRIPTION
Patching the overridden virtual method crashes Torch.

I suggest loading this Harmony based plugin instead: [DefIdToStringFix](https://torchapi.com/plugins/view/e368127c-0676-4ff0-9e8c-f32207dcb12a)

---

MyDefinitionId.ToString fix (performance, deadlock).

UNTESTED! The Torch integration most likely needs to be fixed. 

The algorithm should just work, it has been tested extensively with the previous game version.