### PR TITLE
Make sure torch will only try to run as service when requested

### DIFF
--- a/Torch.Server/Torch.Server.csproj
+++ b/Torch.Server/Torch.Server.csproj
@@ -148,6 +148,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>


### PR DESCRIPTION
Prior to this change, torch will try to run as a service if the environment is non-interactive and OS is not Windows Server 2019/2022, which is incorrect and will cause issues when being ran without GUI on other OSes.

This PR should Fix #449 by explicitly checking if process was started by services host and not the user.