### PR TITLE
Consolidate stop/unload logic and threading across all places.

### DIFF
--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -220,6 +220,7 @@ namespace Torch.Server
                 {
                     config.TempAutostart = true;
                     torch.Stop();
+                    torch.Destroy();
                 }
                 
                 LogManager.Flush();

--- a/Torch.Server/TorchService.cs
+++ b/Torch.Server/TorchService.cs
@@ -45,7 +45,11 @@ namespace Torch.Server
         protected override void OnStop()
         {
             var mre = new ManualResetEvent(false);
-            Task.Run(() => _initializer.Server.Stop());
+            Task.Run(() =>
+            {
+                _initializer.Server.Stop();
+                _initializer.Server.Destroy();
+            });
             if (!mre.WaitOne(TimeSpan.FromMinutes(1)))
                 Process.GetCurrentProcess().Kill();
         }

--- a/Torch.Server/Views/TorchUI.xaml.cs
+++ b/Torch.Server/Views/TorchUI.xaml.cs
@@ -164,8 +164,16 @@ namespace Torch.Server
         {
             var result = MessageBox.Show("Are you sure you want to stop the server?", "Stop Server", MessageBoxButton.YesNo);
 
-            if (result == MessageBoxResult.Yes)
-                _server.Invoke(() => _server.Stop());
+            if (result != MessageBoxResult.Yes)
+            {
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                _server.Stop();
+                _server.Destroy();
+            });
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -180,7 +188,10 @@ namespace Torch.Server
             //_config.Save(); //you idiot
 
             if (_server?.State == ServerState.Running)
+            {
                 _server.Stop();
+                _server.Destroy();
+            }
 
             _scrollTimer.Stop();
             

--- a/Torch/Commands/TorchCommands.cs
+++ b/Torch/Commands/TorchCommands.cs
@@ -341,12 +341,14 @@ namespace Torch.Commands
                             ITorchBase torch = (mod as CommandModule)?.Context?.Torch;
                             Debug.Assert(torch != null);
                             torch.Stop();
+                            torch.Destroy();
                         }, this, TaskContinuationOptions.RunContinuationsAsynchronously);
                     }
                     else
                     {
                         Log.Info("Stopping server.");
-                        Context.Torch.Invoke(() => Context.Torch.Stop());
+                        Context.Torch.Stop();
+                        Context.Torch.Destroy();
                     }
 
                         
@@ -407,7 +409,7 @@ namespace Torch.Commands
                     }
 
                     Log.Warn("Initiating server restart.");
-                    Context.Torch.Invoke(() => Context.Torch.Restart(save));
+                    Context.Torch.Restart(save);
                     yield break;
                 }
 


### PR DESCRIPTION
This resolves most of the cases when torch does not stop or close correctly.
For example when stopping in nogui, the process says running due to game not being fully destroyed.
