### PR TITLE
Add console command listener for nogui scenarios

### DIFF
--- a/Torch.Server/Managers/ConsoleCommandManager.cs
+++ b/Torch.Server/Managers/ConsoleCommandManager.cs
@@ -1,0 +1,62 @@
+﻿using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Torch.API;
+using Torch.API.Managers;
+using Torch.Commands;
+using Torch.Managers;
+
+namespace Torch.Server.Managers
+{
+    internal class ConsoleCommandManager : Manager
+    {
+        private static readonly ILogger Log = LogManager.GetCurrentClassLogger();
+
+        [Dependency]
+        private readonly CommandManager _commandManager;
+
+        public ConsoleCommandManager(ITorchBase torchInstance) : base(torchInstance)
+        {
+        }
+
+        public override void Attach()
+        {
+            if (!Torch.Config.NoGui)
+                return;
+
+            Log.Info("Starting console command listener");
+
+            new Thread(CommandListener)
+            {
+                Name = "Console Command Listener",
+                IsBackground = true,
+            }.Start();
+        }
+
+        private void CommandListener()
+        {
+            while (Torch.GameState < TorchGameState.Unloading)
+            {
+                var line = Console.ReadLine();
+
+                if (line == null)
+                    break;
+
+                Torch.Invoke(() =>
+                {
+                    if (!_commandManager.HandleCommandFromServer(line, LogResponse))
+                        Log.Error("Invalid input '{0}'", line);
+                });
+            }
+        }
+
+        private void LogResponse(TorchChatMessage message)
+        {
+            Log.Info(message.Message);
+        }
+    }
+}

--- a/Torch.Server/Torch.Server.csproj
+++ b/Torch.Server/Torch.Server.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Commands\WhitelistCommands.cs" />
     <Compile Include="FlowDocumentTarget.cs" />
     <Compile Include="ListBoxExtensions.cs" />
+    <Compile Include="Managers\ConsoleCommandManager.cs" />
     <Compile Include="Managers\EntityControlManager.cs" />
     <Compile Include="Managers\GameUpdateManager.cs" />
     <Compile Include="Managers\MultiplayerManagerDedicated.cs" />

--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -73,6 +73,7 @@ namespace Torch.Server
             
             var sessionManager = Managers.GetManager<ITorchSessionManager>();
             sessionManager.AddFactory(x => new MultiplayerManagerDedicated(this));
+            sessionManager.AddFactory(x => new ConsoleCommandManager(this));
             
             // Needs to be done at some point after MyVRageWindows.Init
             // where the debug listeners are registered


### PR DESCRIPTION
In most nogui scenarios, users may want to have easy way of running torch commands without needing a 3rd party solution.
This PR introduces Console Command Listener which would listen for commands coming from console input.