### PR TITLE
Make RestartOnCrash actually restart the server

### DIFF
--- a/Torch.Server/Initializer.cs
+++ b/Torch.Server/Initializer.cs
@@ -298,6 +298,7 @@ quit";
                 Thread.Sleep(5000);
                 var exe = typeof(Program).Assembly.Location;
                 Config.WaitForPID = Process.GetCurrentProcess().Id.ToString();
+                Config.TempAutostart = true;
                 Process.Start(exe, Config.ToString());
             }
             else


### PR DESCRIPTION
Since `RestartOnCrash` config option is called `Restart` and not just `Start`, we would expect it to behave like `!restart` does by enabling temporary autostart so the server comes back online after.

This PR should resolve this difference by always starting game session back when unhandled exception is thrown and `RestartOnCrash` set to true.