### PR TITLE
Leave mod name and description set by game in case steam api doesn't return value

### DIFF
--- a/Torch.Server/ViewModels/ConfigDedicatedViewModel.cs
+++ b/Torch.Server/ViewModels/ConfigDedicatedViewModel.cs
@@ -106,8 +106,14 @@ namespace Torch.Server.ViewModels
                 //else if (!modInfo.Tags.Contains(""))
                 else
                 {
-                    mod.FriendlyName = modInfos[mod.PublishedFileId].Title;
-                    mod.Description = modInfos[mod.PublishedFileId].Description;
+                    var modInfo = modInfos[mod.PublishedFileId];
+                    
+                    if (!string.IsNullOrEmpty(modInfo.Title))
+                        mod.FriendlyName = modInfo.Title;
+
+                    if (!string.IsNullOrEmpty(modInfo.Description))
+                        mod.Description = modInfo.Description;
+
                     //mod.Name = modInfos[mod.PublishedFileId].FileName;
                 }
             }

--- a/Torch.Server/ViewModels/ModItemInfo.cs
+++ b/Torch.Server/ViewModels/ModItemInfo.cs
@@ -135,8 +135,13 @@ namespace Torch.Server.ViewModels
             else
             {
                 Log.Info($"Mod Info successfully retrieved!");
-                FriendlyName = modInfo.Title;
-                Description = modInfo.Description;
+
+                if (!string.IsNullOrEmpty(modInfo.Title))
+                    FriendlyName = modInfo.Title;
+
+                if (!string.IsNullOrEmpty(modInfo.Description))
+                    Description = modInfo.Description;
+                
                 //Name = modInfo.FileName;
                 return true;
             }


### PR DESCRIPTION
Should resolve issues when mod title is missing as anonymous steam api does not return information about unlisted mods.