### PR TITLE
Log command invocation beforehand for silent crashes

### DIFF
--- a/Torch/Commands/CommandManager.cs
+++ b/Torch/Commands/CommandManager.cs
@@ -94,6 +94,7 @@ namespace Torch.Commands
 
             var splitArgs = Regex.Matches(argText, "(\"[^\"]+\"|\\S+)").Cast<Match>().Select(x => x.ToString().Replace("\"", "")).ToList();
             _log.Trace($"Invoking {cmdPath} for server.");
+            _log.Info($"Server is running command '{message}'...");
             var context = new ConsoleCommandContext(Torch, command.Plugin, Sync.MyId, argText, splitArgs);
             if (subscriber != null)
                 context.OnResponse += subscriber;
@@ -166,6 +167,7 @@ namespace Torch.Commands
 
                 var splitArgs = Regex.Matches(argText, "(\"[^\"]+\"|\\S+)").Cast<Match>().Select(x => x.ToString().Replace("\"", "")).ToList();
                 _log.Trace($"Invoking {cmdPath} for player {player.DisplayName}");
+                _log.Info($"Player {player.DisplayName} is running command '{message}'...");
                 var context = new CommandContext(Torch, command.Plugin, steamId, argText, splitArgs);
                 Torch.Invoke(() =>
                 {


### PR DESCRIPTION
Log server/player command invocation in INFO level before the action begins (in addition to after the action ends), so that it's easier to identify an offending command in case of a silent crash.

Silent crash is one of those crashes that wouldn't leave a crash log when it happens. There are cases where a command (cleanup etc) causes it, but currently the invocation is not logged because the server crashes before the log is written down to the file. 

There's a TRACE level log entry but obviously turning TRACE on will flood the log, so I propose adding an INFO level log alongside. This will cause 2 logs (start/end) to emit for every command but IMO that's not an excess. 