### PR TITLE
TorchBase: add server build number

### DIFF
--- a/Torch/TorchBase.cs
+++ b/Torch/TorchBase.cs
@@ -311,10 +311,11 @@ namespace Torch
 
             Debug.Assert(MyPerGameSettings.BasicGameInfo.GameVersion != null, "MyPerGameSettings.BasicGameInfo.GameVersion != null");
             GameVersion = new MyVersion(MyPerGameSettings.BasicGameInfo.GameVersion.Value);
+            var buildNumber = MyPerGameSettings.BasicGameInfo.ServerBuildNumber;
 
             try
             {
-                Console.Title = $"{Config.InstanceName} - Torch {TorchVersion}, SE {GameVersion}";
+                Console.Title = $"{Config.InstanceName} - Torch {TorchVersion}, SE {GameVersion}.{buildNumber}";
             }
             catch
             {
@@ -327,7 +328,7 @@ namespace Torch
             Log.Info("RELEASE");
 #endif
             Log.Info($"Torch Version: {TorchVersion}");
-            Log.Info($"Game Version: {GameVersion}");
+            Log.Info($"Game Version: {GameVersion}.{buildNumber}");
             Log.Info($"Executing assembly: {Assembly.GetEntryAssembly().FullName}");
             Log.Info($"Executing directory: {AppDomain.CurrentDomain.BaseDirectory}");
 


### PR DESCRIPTION
Yesterday Keen pushed a security update, the game is still at version 1.205.26 but the server build number increased from 0 to 1 (and client build number from 0 to 3). The build number is not visible in Torch console title nor in Torch log, but is visible in the Keen log.

In such situation, to be able to quickly check if a server has the latest update, it would be useful to show the server build number more prominently.

This change adds it as a final dot in the version string, as is usual, so the current version will now show as: 1.205.26.1