### PR TITLE
Update Newtonsoft.JSON to non-vulnerable version

### DIFF
--- a/Torch.API/Torch.API.csproj
+++ b/Torch.API/Torch.API.csproj
@@ -44,9 +44,8 @@
       <HintPath>..\GameBinaries\HavokWrapper.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>

--- a/Torch.API/packages.config
+++ b/Torch.API/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.TextTransform" version="1.0.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
   <package id="NLog" version="4.4.12" targetFramework="net461" />
 </packages>

--- a/Torch.Server/Torch.Server.csproj
+++ b/Torch.Server/Torch.Server.csproj
@@ -92,9 +92,8 @@
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\GameBinaries\netstandard.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>

--- a/Torch.Server/packages.config
+++ b/Torch.Server/packages.config
@@ -5,7 +5,7 @@
   <package id="Markdown.Xaml" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Registry" version="4.4.0" targetFramework="net461" />
   <package id="Mono.TextTransform" version="1.0.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
   <package id="NLog" version="4.4.12" targetFramework="net461" />
   <package id="protobuf-net" version="2.4.0" targetFramework="net461" />
   <package id="SteamKit2" version="2.1.0" targetFramework="net461" />


### PR DESCRIPTION
I feel the title is pretty self explanatory. Newtonsoft.JSON versions prior to 13.0.1 are affected by [CVE-2024-21907](https://github.com/advisories/GHSA-5crp-9r3c-p9vr). I know the only real uses of it are in API requests to Torch's website for plugin pulling, but I feel like it is important to be updated.