### PR TITLE
fix(torch.server): GridViewModel, fix KeyNotFoundException crashing T…

### DIFF
--- a/Torch.Server/ViewModels/Entities/GridViewModel.cs
+++ b/Torch.Server/ViewModels/Entities/GridViewModel.cs
@@ -87,9 +87,11 @@ namespace Torch.Server.ViewModels.Entities
                 {
                     var name = playerIdent.DisplayName;
                     if (Owners.ContainsKey(name))
+                    {   
                         Owners[name]--;
-                    if (Owners[name] == 0)
-                        Owners.Remove(name);
+                        if (Owners[name] == 0)
+                            Owners.Remove(name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Owners[name] is not guarded by the if Owners.ContainsKey() check above,  hence it could throw KeyNotFoundException and crash the process.