### PR TITLE
Fixed Console Double Logging

### DIFF
--- a/Torch.Server/Initializer.cs
+++ b/Torch.Server/Initializer.cs
@@ -66,8 +66,6 @@ quit";
             
 #if !DEBUG
             AppDomain.CurrentDomain.UnhandledException += HandleException;
-            LogManager.Configuration.AddRule(LogLevel.Info, LogLevel.Fatal, "console");
-            LogManager.ReconfigExistingLoggers();
 #endif
 
 #if DEBUG


### PR DESCRIPTION
Fixes a double-logging issue affecting Release builds, most visible during the SteamCMD update phase at startup where every line appeared twice in the console. The fix removes a redundant logging rule that was being added at runtime, which duplicated a rule already defined in NLog.config and caused every message to be written to the console twice.