### PR TITLE
Fix for world selection.

### DIFF
--- a/Torch.Server/ViewModels/ConfigDedicatedViewModel.cs
+++ b/Torch.Server/ViewModels/ConfigDedicatedViewModel.cs
@@ -29,7 +29,6 @@ namespace Torch.Server.ViewModels
         public ConfigDedicatedViewModel(MyConfigDedicated<MyObjectBuilder_SessionSettings> configDedicated)
         {
             _config = configDedicated;
-            //_config.IgnoreLastSession = true;
             SessionSettings = new SessionSettingsViewModel(_config.SessionSettings);
             Task.Run(() => UpdateAllModInfosAsync());
         }
@@ -39,8 +38,9 @@ namespace Torch.Server.ViewModels
             Validate();
 
             _config.SessionSettings = _sessionSettings;
-            // Never ever
-            //_config.IgnoreLastSession = true;
+            // LastSession.sbl auto-resume has no purpose on a Torch server (the world to load
+            // is always set explicitly via LoadWorld) and overrides the selected world, so disable it.
+            _config.IgnoreLastSession = true;
             _config.Save(path);
         }
 


### PR DESCRIPTION
This forces ignorelastsession to true, fixing the world selection drop-down. If ignorelastsession is false, which it is by default, you are unable to change your world with the configuration drop-down menu.

The "last session" option comes from the single-player side, where it controls the "Continue Game" button on the main menu. It serves no meaningful purpose in a Torch environment but will introduce bugs like the world selection issue. Jimmacle did this fix years ago and commented it out, but has since mentioned *several* times that somebody needs to re-implement it. :P

This PR also fixes Issue #549 