### PR TITLE
Fix for Import Config freezing.

### DIFF
--- a/Torch.Server/Managers/InstanceManager.cs
+++ b/Torch.Server/Managers/InstanceManager.cs
@@ -134,11 +134,23 @@ namespace Torch.Server.Managers
 
         public void ImportSelectedWorldConfig()
         {
+            if (DedicatedConfig.SelectedWorld == null)
+            {
+                Log.Warn("No world selected; cannot import world config.");
+                return;
+            }
+
             ImportWorldConfig(DedicatedConfig.SelectedWorld, false);
         }
 
         private void ImportWorldConfig(WorldViewModel world, bool modsOnly = true)
         {
+            if (world?.WorldConfiguration == null)
+            {
+                Log.Warn("Cannot import world config: no world or world configuration available.");
+                return;
+            }
+
             var mods = new MtObservableList<ModItemInfo>();
             foreach (var mod in world.WorldConfiguration.Mods)
                 mods.Add(new ModItemInfo(mod));

--- a/Torch.Server/Views/ConfigControl.xaml.cs
+++ b/Torch.Server/Views/ConfigControl.xaml.cs
@@ -106,6 +106,13 @@ namespace Torch.Server.Views
 
         private void ImportConfig_OnClick(object sender, RoutedEventArgs e)
         {
+            if (_instanceManager.DedicatedConfig?.SelectedWorld == null)
+            {
+                MessageBox.Show("Please select a world before attempting to import its configs.",
+                    "No World Selected", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             _instanceManager.ImportSelectedWorldConfig();
         }
 


### PR DESCRIPTION
Fixes Torch freezing when "Import World Config" is clicked with no world selected. Adds a popup prompting the user to select a world first, plus null-checks so the import path can't crash.

Fixes Issue #619 