### PR TITLE
Fix for Restart Bug

### DIFF
--- a/Torch.Server/TorchServer.cs
+++ b/Torch.Server/TorchServer.cs
@@ -226,7 +226,7 @@ namespace Torch.Server
         /// </summary>
         public override void Restart(bool save = true)
         {
-            if (Config.DisconnectOnRestart)
+            if (IsRunning && Config.DisconnectOnRestart)
             {
                 ModCommunication.SendMessageToClients(new JoinServerMessage("0.0.0.0:25555"));
                 Log.Info("Ejected all players from server for restart.");


### PR DESCRIPTION
Fixes the server failing to start after being stopped when DisconnectOnRestart is enabled.

The player-eject now only runs if the server is actually running, allowing the server to start again from the GUI. 