### PR TITLE
Fix Config Lockout

### DIFF
--- a/Torch.Server/Managers/InstanceManager.cs
+++ b/Torch.Server/Managers/InstanceManager.cs
@@ -199,12 +199,12 @@ namespace Torch.Server.Managers
             }
         }
 
-        public void SaveConfig()
+        public bool SaveConfig()
         {
             if (((TorchServer)Torch).HasRun)
             {
                 Log.Warn("Checkpoint cache is stale, not saving dedicated config.");
-                return;
+                return false;
             }
             
             DedicatedConfig.Save(Path.Combine(Torch.Config.InstancePath, CONFIG_NAME));
@@ -238,6 +238,8 @@ namespace Torch.Server.Managers
                 Log.Error("Failed to write sandbox config, changes will not appear on server");
                 Log.Error(e);
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Torch.Server/Views/ConfigControl.xaml.cs
+++ b/Torch.Server/Views/ConfigControl.xaml.cs
@@ -41,7 +41,8 @@ namespace Torch.Server.Views
             
             _server.PropertyChanged += (sender, args) =>
             {
-                if (args.PropertyName == nameof(TorchServer.CanRun))
+                if (args.PropertyName == nameof(TorchServer.CanRun) ||
+                    args.PropertyName == nameof(TorchServer.HasRun))
                 {
                     Dispatcher.Invoke(SetReadOnly);
                 }
@@ -166,58 +167,59 @@ namespace Torch.Server.Views
         
         private void SetReadOnly()
         {
+            // Config is only editable before the first start of the session. After the server
+            // has run the checkpoint is stale and saving is blocked, so the
+            // entire panel is locked even after a stop.
+            bool editable = _server.CanRun && !_server.HasRun;
+
             foreach (var textbox in GetAllChildren<TextBox>(this))
             {
-                // Don't make inherently read-only textboxes editable
-                // (e.g., AnalyticsToken with ReadOnly=true in DisplayAttribute)
-                if (!_server.CanRun)
-                    textbox.IsReadOnly = true;
-                // Only make editable if it wasn't marked as inherently read-only
-                // We use Tag to track this - PropertyGrid doesn't set Tag on TextBoxes
-                else if (textbox.Tag as string != "InherentlyReadOnly")
-                {
-                    // Check if this is the first time and textbox is already read-only
-                    // If so, mark it as inherently read-only
-                    if (textbox.IsReadOnly && textbox.Tag == null)
-                        textbox.Tag = "InherentlyReadOnly";
-                    else
-                        textbox.IsReadOnly = false;
-                }
+                // Track fields that are inherently read-only (Such as AnalyticsToken)
+                // so they stay read-only even when the panel is editable.
+                if (textbox.IsReadOnly && textbox.Tag == null)
+                    textbox.Tag = "InherentlyReadOnly";
+
+                bool inherentlyReadOnly = textbox.Tag as string == "InherentlyReadOnly";
+
+                // Gray out when the panel is locked, otherwise enable- but keep
+                // inherently-read-only fields non-editable.
+                textbox.IsEnabled = editable;
+                textbox.IsReadOnly = !editable || inherentlyReadOnly;
             }
 
             foreach (var button in GetAllChildren<Button>(this))
             {
-                button.IsEnabled = _server.CanRun;
+                button.IsEnabled = editable;
             }
 
             foreach (var comboBox in GetAllChildren<ComboBox>(this))
             {
-                comboBox.IsEnabled = _server.CanRun;
+                comboBox.IsEnabled = editable;
             }
             
             foreach (var slider in GetAllChildren<Slider>(this))
             {
-                slider.IsEnabled = _server.CanRun;
+                slider.IsEnabled = editable;
             }
             
             foreach (var checkbox in GetAllChildren<CheckBox>(this))
             {
-                checkbox.IsEnabled = _server.CanRun;
+                checkbox.IsEnabled = editable;
             }
             
             foreach (var toggleButton in GetAllChildren<ToggleButton>(this))
             {
-                toggleButton.IsEnabled = _server.CanRun;
+                toggleButton.IsEnabled = editable;
             }
             
             foreach (var radioButton in GetAllChildren<RadioButton>(this))
             {
-                radioButton.IsEnabled = _server.CanRun;
+                radioButton.IsEnabled = editable;
             }
             
             foreach (var listBox in GetAllChildren<ListBox>(this))
             {
-                listBox.IsEnabled = _server.CanRun;
+                listBox.IsEnabled = editable;
             }
         }
     }

--- a/Torch.Server/Views/ModListControl.xaml.cs
+++ b/Torch.Server/Views/ModListControl.xaml.cs
@@ -97,7 +97,12 @@ namespace Torch.Server.Views
 
         private void SaveBtn_OnClick(object sender, RoutedEventArgs e)
         {
-            _instanceManager.SaveConfig();
+            if (!_instanceManager.SaveConfig())
+            {
+                MessageBox.Show(
+                    "Configurations are only editable before the first start. If you have autostart enabled, you must disable it before making changes.",
+                    "Configuration Not Saved!", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
         }
 
 


### PR DESCRIPTION
Fixes config fields becoming editable again after stopping a server that had already started. Previously you could edit fields but saving them was impossible, only a log warning alerted the user. Now the whole config panel stays grayed out once the server has run, and the mod list's "Save Config" button shows a popup explaining why the save didn't go through.